### PR TITLE
introduce `thounsands` crate to make large numbers readable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "surf",
+ "thousands",
 ]
 
 [[package]]
@@ -1418,6 +1419,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ serde = { version = "1.0.144", features = ["derive"] }
 async-std = { version = "1.12.0", features = ["attributes"] }
 serde_derive = "1.0.144"
 serde_json = "1.0.85"
+thousands = "0.2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ extern crate clap;
 extern crate surf;
 use clap::{App, Arg};
 use std::fmt::Write;
+use thousands::Separable;
 
 #[macro_use]
 extern crate serde_derive;
@@ -109,12 +110,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
         )
         .unwrap();
         writeln!(target_string, "---- Elastic Cloud コストレポート ----").unwrap();
-        writeln!(target_string, "今月のトータル: {} $", res.costs.total).unwrap();
-        writeln!(target_string, "コスト/時間: {} $", res.hourly_rate).unwrap();
+        writeln!(
+            target_string,
+            "今月のトータル: ${}",
+            res.costs.total.separate_with_commas()
+        )
+        .unwrap();
+        writeln!(
+            target_string,
+            "コスト/時間: ${}",
+            res.hourly_rate.separate_with_commas()
+        )
+        .unwrap();
         writeln!(target_string).unwrap();
         writeln!(target_string, "## コスト種別").unwrap();
         for dimension in &res.costs.dimensions {
-            writeln!(target_string, "{}: {} $", dimension.typ, dimension.cost).unwrap();
+            writeln!(
+                target_string,
+                "{}: ${}",
+                dimension.typ,
+                dimension.cost.separate_with_commas()
+            )
+            .unwrap();
         }
 
         post_slack(slack_url, &target_string).await.unwrap();


### PR DESCRIPTION
SSIA

In current main, the cost will be displayed like `1234.56 $`.
This PR changes this format into `$1,234.56` (separated by comma for every three digits and `$` is placed at the prefix).